### PR TITLE
Mirja's Follow-up: TFO

### DIFF
--- a/draft-ietf-tcpm-converters.mkd
+++ b/draft-ietf-tcpm-converters.mkd
@@ -1094,7 +1094,7 @@ addresses {{RFC6890}}. If a Converter receives a Connect TLVs with such invalid 
 We distinguish two types of Connect TLV based on their length: (1) the Base
 Connect TLV has a length of 20 bytes and contains a remote address and a
 remote port ({{fig-connect}}), (2) the Extended Connect TLV spans more than 20 bytes and also
-includes the optional 'TCP Options' field ({{fig-econnect}}).
+includes the optional 'TCP Options' field ({{fig-econnect}}).     
 This field is used to request the advertisement of specific TCP options 
 to the server.
 
@@ -1178,7 +1178,7 @@ used according to its local policies. For the TCP options that are included
 in the TCP Options field without an optional value, the Transport
 Converter MUST generate its own value. For the TCP options that are
 included in the 'TCP Options' field with
-an optional value, it MUST copy the entire option in the SYN sent to the remote server. This feature is required to support TCP Fast Open. See {{sec-tcpoptions}} for a detailed discussion of the different types of TCP options.
+an optional value, it MUST copy the entire option in the SYN sent to the remote server. This procedure is designed with TFO in mind. Particularly, this procedure allows to successfully exchange a TFO Cookie between the client and the server. See {{sec-tcpoptions}} for a detailed discussion of the different types of TCP options.
 
 The Transport Converter may refuse a Connect TLV request for various reasons
 (e.g., authorization failed, out of resources, invalid


### PR DESCRIPTION
> 
> The other point is basically point 12 below about the TCP option field in the Connect TLV (also related to point 17 below). This is not well enough specified and seem also quite complex as a generic mechanism. I would think the converter should usually try to use the same option as the client did send in his SYN to the converter, if supported by the converter TCP implementation. The TFO cookie might be a special case. I’m not sure if that needs to be generalised or if having a separate TLV for that one case might be simpler. Please also reconsider this but in any case it needs more explanation in the spec.
> 
> We tried to keep the text as simple as possible and as close to the one accepted by the wg last call. We now have two types of Connect TLV:
> 	• The Base Connect TLV which does not carry any TCP option
> 	• The Extended Connect TLV which carries TCP option
> 
> We expect that the Base Connect will be used by most implementations. The Extended Connect is required to support TFO.

So for me this is now only an editorial change. However, if the group supports this design that of course also okay for me. I would however recommend to mention more explicitly in this section that the main (and currently only) use case for this is TFO cookies.