### PR TITLE
Mirja's follow-up

### DIFF
--- a/draft-ietf-tcpm-converters.mkd
+++ b/draft-ietf-tcpm-converters.mkd
@@ -897,6 +897,8 @@ This section defines the Convert Protocol (Convert, for short) messages that are
 
 The Transport Converter listens on a dedicated TCP port number for Convert messages from Clients. That port number is configured by an administrator.
 
+Convert messages may appear only in a SYN, SYN+ACK, or in an ACK that is sent shortly after the SYN+ACK.
+
 Convert messages MUST be included as the first bytes of the bytestream. All Convert messages starts with a 32 bits long fixed header ({{sec-header}}) followed by one or more Convert TLVs (Type, Length, Value) ({{sec-tlv}}). 
 
  


### PR DESCRIPTION
"Thx. However, I think it would still be good to clarify which packets can carry Convert message. I assume you are saying now that there are no restrictions and a Convert exchange can go on for multiple RTT before the actually data transmission is started? Is that correct? 

However, I guess in mist cases (and all changes specified in this doc) you only have convert messages in the syn and syn/ack, and potentially also in the 3rd ack of the handshake but that’s only an error and the connection is closed/reset afterwards. If that is correct, I think that would actually be good to say somewhere early in the document.
"