### PR TITLE
Mirja's follow-up: error tlv

### DIFF
--- a/draft-ietf-tcpm-converters.mkd
+++ b/draft-ietf-tcpm-converters.mkd
@@ -1264,6 +1264,8 @@ information about some errors that occurred during the processing
 of a Convert message. This TLV has a variable length. Upon reception of
 an Error TLV, a Client MUST reset the associated connection.
 
+An Error TLV can be sent in the SYN+ACK or an ACK sent shortly after the SYN+ACK.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
                       1                   2                   3
   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1


### PR DESCRIPTION
"Can only error message be included in non-SYN packets or other messages as well? I think for this it still would be good to add more clarification in the draft. "